### PR TITLE
Display all exercises in ExerciseCombobox

### DIFF
--- a/client/src/components/ExerciseCard.tsx
+++ b/client/src/components/ExerciseCard.tsx
@@ -240,7 +240,6 @@ export default function ExerciseCard({
             <ExerciseCombobox
               value={exercise.name}
               onSelect={handleExerciseSelect}
-              filter={workoutType}
             />
           )}
 

--- a/client/src/components/ExerciseCombobox.tsx
+++ b/client/src/components/ExerciseCombobox.tsx
@@ -27,16 +27,10 @@ interface ExerciseOption {
 interface ExerciseComboboxProps {
   value: string;
   onSelect: (value: string) => void;
-  filter: "strength" | "cardio" | "core" | "sports"; // New prop to filter by
 }
 
-export default function ExerciseCombobox({ value, onSelect, filter }: ExerciseComboboxProps) {
+export default function ExerciseCombobox({ value, onSelect }: ExerciseComboboxProps) {
   const [open, setOpen] = useState(false);
-
-  // Filter the master list based on the workout type
-  const filteredExercises = masterExerciseList.filter(
-    (exercise) => exercise.category === filter
-  );
 
   return (
     <Popover open={open} onOpenChange={setOpen}>
@@ -57,7 +51,7 @@ export default function ExerciseCombobox({ value, onSelect, filter }: ExerciseCo
           <CommandList>
             <CommandEmpty>No exercise found.</CommandEmpty>
             <CommandGroup>
-              {filteredExercises.map((exercise) => (
+              {masterExerciseList.map((exercise) => (
                 <CommandItem
                   key={exercise.id}
                   value={exercise.name}


### PR DESCRIPTION
## Summary
- Remove category filter prop from ExerciseCombobox and show the full exercise list
- Update ExerciseCard to use the simplified ExerciseCombobox without filter parameter

## Testing
- `npm test` *(fails: Missing script "test" )*
- `npm run check` *(fails: TypeScript error in server/vite.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68a4e200cea8832fbb30cdde96237215