### PR TITLE
refactor: simplify ExerciseCard props

### DIFF
--- a/client/src/components/ExerciseCard.tsx
+++ b/client/src/components/ExerciseCard.tsx
@@ -11,7 +11,6 @@ import { equipmentIcons } from "@/icons/equipmentIcons";
 
 interface ExerciseCardProps {
   exercise: Exercise;
-  workoutType: "strength" | "cardio" | "core" | "sports";
   onUpdate: (data: Partial<Exercise>) => void;
   onDelete: () => void;
   startOpen?: boolean;
@@ -26,7 +25,6 @@ interface LastPerformance {
 
 export default function ExerciseCard({
   exercise,
-  workoutType,
   onUpdate,
   onDelete,
   startOpen = false,
@@ -55,7 +53,7 @@ export default function ExerciseCard({
 
   const handleExerciseSelect = (exerciseName: string) => {
     const selected = masterExerciseList.find((ex) => ex.name === exerciseName);
-    const category = selected ? selected.category : workoutType;
+    const category = selected ? selected.category : exercise.type;
 
     const updates: Partial<Exercise> = {
       name: exerciseName,
@@ -240,7 +238,6 @@ export default function ExerciseCard({
             <ExerciseCombobox
               value={exercise.name}
               onSelect={handleExerciseSelect}
-              filter={workoutType}
             />
           )}
 

--- a/client/src/components/ExerciseCombobox.tsx
+++ b/client/src/components/ExerciseCombobox.tsx
@@ -27,16 +27,16 @@ interface ExerciseOption {
 interface ExerciseComboboxProps {
   value: string;
   onSelect: (value: string) => void;
-  filter: "strength" | "cardio" | "core" | "sports"; // New prop to filter by
+  filter?: "strength" | "cardio" | "core" | "sports"; // Optional prop to filter by
 }
 
 export default function ExerciseCombobox({ value, onSelect, filter }: ExerciseComboboxProps) {
   const [open, setOpen] = useState(false);
 
-  // Filter the master list based on the workout type
-  const filteredExercises = masterExerciseList.filter(
-    (exercise) => exercise.category === filter
-  );
+  // Filter the master list based on the workout type if provided
+  const filteredExercises = filter
+    ? masterExerciseList.filter((exercise) => exercise.category === filter)
+    : masterExerciseList;
 
   return (
     <Popover open={open} onOpenChange={setOpen}>

--- a/client/src/pages/Workout.tsx
+++ b/client/src/pages/Workout.tsx
@@ -576,7 +576,6 @@ export default function WorkoutPage({
                             onDelete={() => deleteExercise(exercise.id)}
                             workoutExercises={exercises}
                             startOpen={exercise.id === lastAddedExerciseId}
-                            workoutType={workoutType}
                           />
                         ))}
                       </div>
@@ -610,7 +609,6 @@ export default function WorkoutPage({
                         onDelete={() => deleteExercise(exercise.id)}
                         workoutExercises={exercises}
                         startOpen={exercise.id === lastAddedExerciseId}
-                        workoutType={workoutType}
                       />
 
                       {/* + Button to group with next */}

--- a/server/vite.ts
+++ b/server/vite.ts
@@ -1,7 +1,11 @@
 import express, { type Express } from "express";
 import fs from "fs";
 import path from "path";
-import { createServer as createViteServer, createLogger } from "vite";
+import {
+  createServer as createViteServer,
+  createLogger,
+  type ServerOptions,
+} from "vite";
 import { type Server } from "http";
 import viteConfig from "../vite.config";
 import { nanoid } from "nanoid";
@@ -20,7 +24,7 @@ export function log(message: string, source = "express") {
 }
 
 export async function setupVite(app: Express, server: Server) {
-  const serverOptions = {
+  const serverOptions: ServerOptions = {
     middlewareMode: true,
     hmr: { server },
     allowedHosts: true,


### PR DESCRIPTION
## Summary
- drop `workoutType` prop from `ExerciseCard` and default selection to `exercise.type`
- allow `ExerciseCombobox` to accept optional filter
- type Vite server options to satisfy TypeScript check

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68a4e233f704832f95e510c94200c473