### PR TITLE
feat: derive workout type from exercises

### DIFF
--- a/client/src/components/ExerciseCard.tsx
+++ b/client/src/components/ExerciseCard.tsx
@@ -11,7 +11,6 @@ import { equipmentIcons } from "@/icons/equipmentIcons";
 
 interface ExerciseCardProps {
   exercise: Exercise;
-  workoutType: "strength" | "cardio" | "core" | "sports";
   onUpdate: (data: Partial<Exercise>) => void;
   onDelete: () => void;
   startOpen?: boolean;
@@ -26,7 +25,6 @@ interface LastPerformance {
 
 export default function ExerciseCard({
   exercise,
-  workoutType,
   onUpdate,
   onDelete,
   startOpen = false,
@@ -55,11 +53,11 @@ export default function ExerciseCard({
 
   const handleExerciseSelect = (exerciseName: string) => {
     const selected = masterExerciseList.find((ex) => ex.name === exerciseName);
-    const category = selected ? selected.category : workoutType;
+    const category = selected ? selected.category : exercise.type;
 
     const updates: Partial<Exercise> = {
       name: exerciseName,
-      type: category as any,
+      type: (category as any) || "strength",
       equipment: Array.isArray(selected?.equipment)
         ? selected?.equipment
         : selected?.equipment
@@ -240,7 +238,13 @@ export default function ExerciseCard({
             <ExerciseCombobox
               value={exercise.name}
               onSelect={handleExerciseSelect}
-              filter={workoutType}
+              filter={
+                (exercise.type || "strength") as
+                  | "strength"
+                  | "cardio"
+                  | "core"
+                  | "sports"
+              }
             />
           )}
 


### PR DESCRIPTION
## Summary
- derive workout type from selected exercises
- default new exercises to strength and infer type when saving workouts/templates
- drop manual workout type selection and related ExerciseCard prop

## Testing
- `npm test` (fails: Missing script "test")
- `npm run check` (fails: server/vite.ts Type '{ middlewareMode: boolean; ... }' is not assignable to type 'ServerOptions')

------
https://chatgpt.com/codex/tasks/task_e_68a4e2348638832fa96176855c562f5f