### PR TITLE
refactor: compute workout type on save

### DIFF
--- a/client/src/pages/Workout.tsx
+++ b/client/src/pages/Workout.tsx
@@ -40,9 +40,6 @@ export default function WorkoutPage({
   const [exercises, setExercises] = useState<Exercise[]>([]);
   const [templates, setTemplates] = useState<Template[]>([]);
   const [showTemplateDialog, setShowTemplateDialog] = useState(false);
-  const [workoutType, setWorkoutType] = useState<
-    "strength" | "cardio" | "core" | "sports"
-  >("sports");
   const [workoutDate, setWorkoutDate] = useState(
     new Date().toISOString().split("T")[0]
   );
@@ -79,10 +76,6 @@ export default function WorkoutPage({
       })
     );
   };
-
-  useEffect(() => {
-    setWorkoutType(determineWorkoutType(exercises));
-  }, [exercises]);
 
   useEffect(() => {
     setTemplates(storage.getTemplates());


### PR DESCRIPTION
## Summary
- remove unused workoutType state and effect
- compute workout type via determineWorkoutType inside saveWorkout

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run check` *(fails: TS2322 in server/vite.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68a6385b9e74832f8a92c4a582e57aa1