### PR TITLE
Show all exercises in combobox and derive type on selection

### DIFF
--- a/client/src/components/ExerciseCard.tsx
+++ b/client/src/components/ExerciseCard.tsx
@@ -53,11 +53,10 @@ export default function ExerciseCard({
 
   const handleExerciseSelect = (exerciseName: string) => {
     const selected = masterExerciseList.find((ex) => ex.name === exerciseName);
-    const category = selected ? selected.category : exercise.type;
 
     const updates: Partial<Exercise> = {
       name: exerciseName,
-      type: (category as any) || "strength",
+      type: (selected?.category as any) || exercise.type || "strength",
       equipment: Array.isArray(selected?.equipment)
         ? selected?.equipment
         : selected?.equipment
@@ -238,13 +237,6 @@ export default function ExerciseCard({
             <ExerciseCombobox
               value={exercise.name}
               onSelect={handleExerciseSelect}
-              filter={
-                (exercise.type || "strength") as
-                  | "strength"
-                  | "cardio"
-                  | "core"
-                  | "sports"
-              }
             />
           )}
 

--- a/client/src/components/ExerciseCombobox.tsx
+++ b/client/src/components/ExerciseCombobox.tsx
@@ -27,16 +27,10 @@ interface ExerciseOption {
 interface ExerciseComboboxProps {
   value: string;
   onSelect: (value: string) => void;
-  filter: "strength" | "cardio" | "core" | "sports"; // New prop to filter by
 }
 
-export default function ExerciseCombobox({ value, onSelect, filter }: ExerciseComboboxProps) {
+export default function ExerciseCombobox({ value, onSelect }: ExerciseComboboxProps) {
   const [open, setOpen] = useState(false);
-
-  // Filter the master list based on the workout type
-  const filteredExercises = masterExerciseList.filter(
-    (exercise) => exercise.category === filter
-  );
 
   return (
     <Popover open={open} onOpenChange={setOpen}>
@@ -57,7 +51,7 @@ export default function ExerciseCombobox({ value, onSelect, filter }: ExerciseCo
           <CommandList>
             <CommandEmpty>No exercise found.</CommandEmpty>
             <CommandGroup>
-              {filteredExercises.map((exercise) => (
+              {masterExerciseList.map((exercise) => (
                 <CommandItem
                   key={exercise.id}
                   value={exercise.name}


### PR DESCRIPTION
## Summary
- Remove category filter from ExerciseCombobox so all exercises are listed
- Stop passing filter prop from ExerciseCard
- Preserve exercise type by deriving it from the selected exercise's category

## Testing
- `npm test` (fails: Missing script "test")
- `npm run check` (fails: TS2322 in server/vite.ts)


------
https://chatgpt.com/codex/tasks/task_e_68a6384ad5b0832f8a1885ed89817e9c